### PR TITLE
Fix vector underflow in honeybee center filtering

### DIFF
--- a/apps/rpicam_honeybee.cpp
+++ b/apps/rpicam_honeybee.cpp
@@ -470,20 +470,26 @@ void traceSecondDerivate()
 			}
 		}
 
-		for (int i = 0; i < centers.size(); i++)
-		{
-			for (int j = i + 1; j < centers.size(); j++)
-			{
-				double distance = calculateEuclidDistance(std::get<0>(centers[i]), std::get<0>(centers[j]));
-				// std::cout << distance << " / ";
-				if (distance < 11)
-				{
-					centers.erase(centers.begin() + j);
-					i--;
-					j--;
-				}
-			}
-		}
+                // Remove points that are too close to each other. The previous
+                // implementation modified the loop variable `i` inside the inner
+                // loop which could make `i` negative and lead to invalid vector
+                // indexing.  Use size_t indices and only adjust the inner index
+                // when erasing to keep the iteration valid.
+                for (size_t i = 0; i < centers.size(); ++i)
+                {
+                        for (size_t j = i + 1; j < centers.size();)
+                        {
+                                double distance = calculateEuclidDistance(std::get<0>(centers[i]), std::get<0>(centers[j]));
+                                if (distance < 11)
+                                {
+                                        centers.erase(centers.begin() + j);
+                                }
+                                else
+                                {
+                                        ++j;
+                                }
+                        }
+                }
 		// std::cout<<std::endl;
 
 		// cv::imshow("center",center * 100);


### PR DESCRIPTION
## Summary
- prevent negative loop index when pruning nearby points in `traceSecondDerivate`

## Testing
- `meson setup build` *(fails: command not found)*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689751eb11b4832ebb16ae4981331741